### PR TITLE
Switch to user 1001 in Dockerfile.tests

### DIFF
--- a/openshift-ci/Dockerfile.tests
+++ b/openshift-ci/Dockerfile.tests
@@ -6,4 +6,6 @@ ENV GIT_COMMITTER_EMAIL devtools@redhat.com
 
 WORKDIR /go/src/github.com/redhat-developer/helm
 
+USER 1001
+
 COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:
Switches user in Dockerfile for unit tests to be `1001` to avoid:
```
Failed to get name of current user: user: unknown userid 1190030000
```
error.
